### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,6 @@
 		<title>Astro</title>
 	</head>
 	<body>
-		<h1>Astro 3</h1>
+		<h1>Astro 5</h1>
 	</body>
 </html>


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement